### PR TITLE
Feat: Alerting System

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Probes are defined in the configuration file. Each probe has the following prope
   - `timeout`: The timeout in milliseconds for the request.
   - `method`: The HTTP method to use for the request.
   - `url`: The URL to make the request to.
-  - `recoveryThreshold`: The number of times the probe should recover before marking it as an incident.
-  - `incidentThreshold`: The number of times the probe should fail before marking it as an incident.
+  - `recoveryThreshold`: The number of times the probe should recover before marking it as an incident. By default, it will use the largest value of `recoveryThreshold` from all requests.
+  - `incidentThreshold`: The number of times the probe should fail before marking it as an incident. By default, it will use the largest value of `incidentThreshold` from all requests.
   - `alerts`: An array of alerts to be evaluated for the probe. (More details below)
     - `query`: The query to evaluate.
     - `message`: The message to send if the query evaluates to true.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Monika is a monitoring tool that runs probes and sends notifications when a prob
 
 - HTTP probes
 - Ping probes
+- Alerting system
 - Notifications
   - Discord
 
@@ -55,8 +56,98 @@ Probes are defined in the configuration file. Each probe has the following prope
   - `url`: The URL to make the request to.
   - `recoveryThreshold`: The number of times the probe should recover before marking it as an incident.
   - `incidentThreshold`: The number of times the probe should fail before marking it as an incident.
-- `ping`: Indicates that the probe is a Ping probe 
+  - `alerts`: An array of alerts to be evaluated for the probe. (More details below)
+    - `query`: The query to evaluate.
+    - `message`: The message to send if the query evaluates to true.
+- `ping`: Indicates that the probe is a Ping probe
   - `uri`: The URI to ping
+
+### Alerts
+
+Alerts allows you to define conditions for triggering alerts based on HTTP probe responses. Each alert has the following properties:
+
+- `query`: The query to evaluate.
+- `message`: The message to send if the query evaluates to true.
+
+#### Alert Expression Syntax
+
+Alerts in Monika are defined using expressions that evaluate to boolean values. These expressions are evaluated against the response data of your HTTP probes. If an expression evaluates to true, the alert is triggered.
+
+**WARNING**: The expression language used in [Monika](https://github.com/hyperjumptech/monika) is not the same as the one used in [Monika GO](https://github.com/hyperjumptech/monika-go).
+
+##### Available Response Data
+
+| Variable           | Type   | Description                         |
+| ------------------ | ------ | ----------------------------------- |
+| `response.status`  | Number | HTTP status code of the response    |
+| `response.time`    | Number | Response time in milliseconds       |
+| `response.body`    | String | Response body as a string           |
+| `response.headers` | Map    | Response headers as key-value pairs |
+| `response.size`    | Number | Size of the response in bytes       |
+
+##### Expression Examples
+
+```yaml
+# Alert when HTTP status code is not a success (not in the 200-299 range)
+response.status < 200 || response.status > 299
+
+# Alert when response time is greater than 2000 milliseconds
+response.time > 2000
+
+# Alert when response body contains the word "error"
+contains(response.body, "error")
+
+# Alert when a specific header is missing
+response.headers["Content-Type"] == nil
+
+# Alert when response size is too large
+response.size > 1000000  # Over 1MB
+
+# Combining multiple conditions
+response.time > 1000 && (response.status != 200 || contains(response.body, "error"))
+```
+
+#### Operators and Functions
+
+The expr language supports a variety of operators and functions:
+
+##### Arithmetic Operators
+
+- `+` (addition)
+- `-` (subtraction)
+- `*` (multiplication)
+- `/` (division)
+- `%` (modulo)
+
+##### Comparison Operators
+
+- `==` (equal)
+- `!=` (not equal)
+- `<` (less than)
+- `>` (greater than)
+- `<=` (less than or equal)
+- `>=` (greater than or equal)
+
+##### Logical Operators
+
+- `&&` (logical AND)
+- `||` (logical OR)
+- `!` (logical NOT)
+
+##### String Functions
+
+- `contains(s, substr)`: Checks if string `s` contains substring `substr`
+- `startsWith(s, prefix)`: Checks if string `s` starts with `prefix`
+- `endsWith(s, suffix)`: Checks if string `s` ends with `suffix`
+- `len(s)`: Returns the length of string `s`
+
+##### Other Functions
+
+- `len(array)`: Returns the length of an array
+- `all(array, predicate)`: Returns true if all elements in the array satisfy the predicate
+- `any(array, predicate)`: Returns true if any element in the array satisfies the predicate
+- `filter(array, predicate)`: Returns a new array with elements that satisfy the predicate
+- `map(array, function)`: Returns a new array with the results of applying the function to each element
 
 ### Notifications
 
@@ -65,7 +156,7 @@ Notifications are defined in the configuration file. Each notification has the f
 - `id`: A unique identifier for the notification.
 - `type`: The type of notification to send.
 - `data`: The data to send with the notification.
-  - `url`: The URL to send the notification to.
+  - `url`: The webhook URL to send the notification to.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require github.com/prometheus-community/pro-bing v0.6.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/expr-lang/expr v1.17.2 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-co-op/gocron/v2 v2.16.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/expr-lang/expr v1.17.2 h1:o0A99O/Px+/DTjEnQiodAgOIK9PPxL8DtXhBRKC+Iso=
+github.com/expr-lang/expr v1.17.2/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-co-op/gocron/v2 v2.16.1 h1:ux/5zxVRveCaCuTtNI3DiOk581KC1KpJbpJFYUEVYwo=

--- a/internal/assertion/assertion.go
+++ b/internal/assertion/assertion.go
@@ -1,0 +1,27 @@
+package alert
+
+import (
+	"github.com/expr-lang/expr"
+)
+
+func Evaluate(expression string, data map[string]interface{}) bool {
+	// Parse the expression
+	program, err := expr.Compile(expression, expr.Env(data))
+	if err != nil {
+		return false
+	}
+
+	// Evaluate the expression
+	result, err := expr.Run(program, data)
+	if err != nil {
+		return false
+	}
+
+	// Convert the result to a boolean
+	boolResult, ok := result.(bool)
+	if !ok {
+		return false
+	}
+
+	return boolResult
+}

--- a/internal/cron/jobs/ssl.go
+++ b/internal/cron/jobs/ssl.go
@@ -26,7 +26,7 @@ func Check(conf *loader.Config) {
 	// We only want to check SSL of HTTPS probes
 	HTTProbes := make([]loader.ConfigProbe, 0)
 	for _, probe := range conf.Probes {
-		if probe.Ping == (loader.ConfigProbePing{}) {
+		if probe.Ping.Uri == "" {
 			HTTProbes = append(HTTProbes, probe)
 		}
 

--- a/internal/probers/http/http.go
+++ b/internal/probers/http/http.go
@@ -1,10 +1,13 @@
 package http
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	assertion "hyperjumptech/monika/internal/assertion"
 	"hyperjumptech/monika/internal/loader"
 	"hyperjumptech/monika/internal/logger"
 	notifier "hyperjumptech/monika/internal/notification"
@@ -27,33 +30,34 @@ type ProbeHealth struct {
 	IncidentThreshold int
 }
 
+// HttpResult represents the result of an HTTP request
 type HttpResult struct {
 	StatusCode   int
 	ResponseTime float64
+	Body         string
+	Headers      map[string]string
+	Size         int
+}
+
+// ProbeStatusReason represents the reason for a probe's status change
+type ProbeStatusReason struct {
+	AlertQuery   string
+	AlertMessage string
+	RequestURL   string
 }
 
 func CreateProbes(config *loader.Config) {
 	logger := logger.GetLogger()
 
 	for _, probe := range config.Probes {
-		// Determine the largest recovery and incident thresholds
-		recoveryThreshold := probe.Requests[0].RecoveryThreshold
-		incidentThreshold := probe.Requests[0].IncidentThreshold
+		var probeHealth *ProbeHealth
 
 		for _, request := range probe.Requests {
-			if request.RecoveryThreshold > recoveryThreshold {
-				recoveryThreshold = request.RecoveryThreshold
+			probeHealth = &ProbeHealth{
+				Status:            HEALTHY,
+				RecoveryThreshold: request.IncidentThreshold,
+				IncidentThreshold: request.RecoveryThreshold,
 			}
-
-			if request.IncidentThreshold > incidentThreshold {
-				incidentThreshold = request.IncidentThreshold
-			}
-		}
-
-		probeHealth := &ProbeHealth{
-			Status:            HEALTHY,
-			RecoveryThreshold: recoveryThreshold,
-			IncidentThreshold: incidentThreshold,
 		}
 
 		// Run probe using goroutine
@@ -65,32 +69,61 @@ func CreateProbes(config *loader.Config) {
 			for {
 				time.Sleep(interval)
 
-				// Make HTTP request to the URL
+				var reason ProbeStatusReason
 				failed := false
+
+				// Make HTTP request to the URL
 				for _, request := range probe.Requests {
 					// Send the request
 					resp, err := sendRequest(request, timeout)
 					logger.Info().Str("context", "probe").Str("type", "http").Msgf("%s - %s - %s - %s - %d - %.3fms", probe.Name, probeHealth.Status, request.Method, request.URL, resp.StatusCode, resp.ResponseTime)
 
+					// If error, mark as failed
 					if err != nil {
-						// If error, mark as failed
+						reason = ProbeStatusReason{
+							AlertQuery:   "error != nil",
+							AlertMessage: err.Error(),
+							RequestURL:   request.URL,
+						}
 						failed = true
 						break
-					} else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-						// If status code is not between 200 and 300, mark as failed
+					}
+
+					// If response time is greater than the timeout, mark as failed
+					if resp.ResponseTime > float64(request.Timeout) {
+						reason = ProbeStatusReason{
+							AlertQuery:   fmt.Sprintf("response.time > %d", request.Timeout),
+							AlertMessage: "Request timed out",
+							RequestURL:   request.URL,
+						}
 						failed = true
 						break
-					} else if resp.ResponseTime > float64(request.Timeout) {
-						// If response time is greater than the timeout, mark as failed
-						failed = true
-						break
-					} else if resp.ResponseTime > 2000 {
-						// If response time is greater than 2 seconds, mark as failed
-						failed = true
-						break
-					} else {
-						// Otherwise, mark as successful
-						failed = false
+					}
+
+					// Evaluate alert query expressions from the config file
+					for _, alert := range request.Alerts {
+						alertTriggered := assertion.Evaluate(alert.Query, map[string]interface{}{
+							"response": map[string]interface{}{
+								"status":  resp.StatusCode,
+								"time":    resp.ResponseTime,
+								"body":    resp.Body,
+								"headers": resp.Headers,
+								"size":    resp.Size,
+							},
+						})
+
+						// Alert condition met, take action
+						if alertTriggered {
+							// Store the reason for the incident
+							reason = ProbeStatusReason{
+								AlertQuery:   alert.Query,
+								AlertMessage: alert.Message,
+								RequestURL:   request.URL,
+							}
+
+							failed = true
+							break
+						}
 					}
 				}
 
@@ -107,14 +140,27 @@ func CreateProbes(config *loader.Config) {
 						if probeHealth.IncidentCount >= probeHealth.IncidentThreshold {
 							probeHealth.Status = INCIDENT
 
+							// Construct a more detailed notification message
+							notificationMsg := fmt.Sprintf(
+								"Probe is now in an incident state\n\n"+
+									"Probe: %s\n"+
+									"Alert: %s\n"+
+									"Message: %s\n"+
+									"URL: %s",
+								probe.Name,
+								reason.AlertQuery,
+								reason.AlertMessage,
+								reason.RequestURL,
+							)
+
 							// Send notification to the configured channel(s)
-							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Probe %s has failed, sending notification to the configured channel(s)", probe.Name)
+							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Probe %s is unhealthy, sending notification to the configured channel(s)", probe.Name)
 							for _, notification := range config.Notifications {
-								notifier.SendNotification(notification, "Probe "+probe.Name+" is now in an incident state")
+								notifier.SendNotification(notification, notificationMsg)
 							}
 						} else {
 							// Else, just log
-							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Probe %s is failing, attempt %d of %d until it may be considered an incident", probe.Name, probeHealth.IncidentCount, probeHealth.IncidentThreshold)
+							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Alert detected for probe %s: %s. Attempt %d of %d until it may be considered an incident", probe.Name, reason.AlertMessage, probeHealth.IncidentCount, probeHealth.IncidentThreshold)
 						}
 					}
 				} else {
@@ -129,14 +175,23 @@ func CreateProbes(config *loader.Config) {
 						if probeHealth.RecoveryCount >= probeHealth.RecoveryThreshold {
 							probeHealth.Status = HEALTHY
 
+							// Construct a more detailed notification message
+							notificationMsg := fmt.Sprintf(
+								"Probe is now in a healthy state\n\n"+
+									"Probe: %s\n"+
+									"All checks passed successfully for %d consecutive attempts",
+								probe.Name,
+								probeHealth.RecoveryThreshold,
+							)
+
 							// Send notification to the configured channel(s)
-							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Probe %s has recovered, sending notification to the configured channel(s)", probe.Name)
+							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Probe %s is healthy, sending notification to the configured channel(s)", probe.Name)
 							for _, notification := range config.Notifications {
-								notifier.SendNotification(notification, "Probe "+probe.Name+" is now in an healthy state")
+								notifier.SendNotification(notification, notificationMsg)
 							}
 						} else {
 							// Else, just log
-							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Probe %s is recovering, attempt %d of %d until it may be considered a recovery", probe.Name, probeHealth.RecoveryCount, probeHealth.RecoveryThreshold)
+							logger.Info().Str("context", "probe").Str("type", "http").Msgf("Alert has been resolved for probe %s: %s. Attempt %d of %d until it may be considered a recovery", probe.Name, reason.AlertMessage, probeHealth.RecoveryCount, probeHealth.RecoveryThreshold)
 						}
 					}
 				}
@@ -165,9 +220,26 @@ func sendRequest(request loader.ConfigProbeRequest, timeout time.Duration) (*Htt
 		return nil, err
 	}
 
+	// Read the response body
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	bodyString := string(bodyBytes)
+
+	// Convert headers from map[string][]string to map[string]string
+	// For headers with multiple values, we'll join them with a comma
+	headers := make(map[string]string)
+	for key, values := range resp.Header {
+		headers[key] = strings.Join(values, ", ")
+	}
+
 	elapsed := time.Since(start)
 	return &HttpResult{
 		StatusCode:   resp.StatusCode,
-		ResponseTime: float64(elapsed.Milliseconds()) / 1_000,
+		ResponseTime: float64(elapsed.Milliseconds()),
+		Body:         bodyString,
+		Headers:      headers,
+		Size:         len(bodyBytes), // More accurate than ContentLength which can be -1
 	}, nil
 }

--- a/internal/probers/probers.go
+++ b/internal/probers/probers.go
@@ -13,7 +13,7 @@ func InitializeProbes(config *loader.Config) {
 
 	// Filter probes based on type
 	for _, probe := range config.Probes {
-		if probe.Ping != (loader.ConfigProbePing{}) {
+		if probe.Ping.Uri != "" {
 			PingProbes = append(PingProbes, probe)
 		} else {
 			HTTPProbes = append(HTTPProbes, probe)


### PR DESCRIPTION
# Monika GO PR

# What does this PR fixes?

This PR fixes #7 

# How does this PR fix it?

This PR adds the feature to set the alerts for each probe. This PR uses https://github.com/expr-lang/expr to compile alert expression.

By default if you do not define the alerts for a request, it will use `response.status < 200 || response.status > 300` and `response.time > 2000`

# How should this PR be tested?

Run [Monika Alert Simulator](https://github.com/hyperjumptech/monika-alert-simulator) first.

1. Create a config
```yaml
probes:
  - id: "1"
    name: GitHub
    description: Multiple
    requests:
      - url: https://github.com
  - id: "2"
    name: Google
    description: Google
    ping:
      uri: google.com
  - id: "3"
    name: Monika Alert Simulator
    description: Threshold based
    interval: 3
    requests:
      - url: http://localhost:8000/api/status?threshold=5
  - id: "4"
    name: Monika Alert Simulator
    description: Threshold based
    interval: 3
    requests:
      - url: http://localhost:8000/api/delay?threshold=5&delay=3000
```
2. `make run`
3. It should return an incident after 5 tries

# Are there any screenshots or videos that show the behavior change?

![image](https://github.com/user-attachments/assets/7f4b4ff4-0cc9-4e44-9699-1572dfca0c52)

# Does this PR introduce a breaking change?

- [] Yes
- [x] No

# Other information

N/A